### PR TITLE
Fix bugs with paging

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".XkcdReaderApplication"
         android:allowBackup="false"
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/androidApp/src/main/java/com/colibrez/xkcdreader/android/DependencyContainer.kt
+++ b/androidApp/src/main/java/com/colibrez/xkcdreader/android/DependencyContainer.kt
@@ -1,0 +1,53 @@
+package com.colibrez.xkcdreader.android
+
+import android.content.Context
+import androidx.compose.ui.platform.LocalContext
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.PagingSource
+import androidx.paging.RemoteMediator
+import app.cash.sqldelight.paging3.QueryPagingSource
+import com.colibrez.xkcdreader.android.data.repository.ComicsRemoteMediator
+import com.colibrez.xkcdreader.data.Database
+import com.colibrez.xkcdreader.data.repository.OfflineFirstComicRepository
+import com.colibrez.xkcdreader.database.DriverFactory
+import com.colibrez.xkcdreader.database.SqlDelightLocalComicDataSource
+import com.colibrez.xkcdreader.database.createDatabase
+import com.colibrez.xkcdreader.model.Comic
+import com.colibrez.xkcdreader.network.ApiClient
+import kotlinx.coroutines.Dispatchers
+
+class DependencyContainer(private val applicationContext: Context) {
+
+    private val database: Database by lazy {
+        createDatabase(DriverFactory(applicationContext))
+    }
+
+    val comicRepository by lazy {
+        OfflineFirstComicRepository(SqlDelightLocalComicDataSource(Dispatchers.IO, database))
+    }
+
+    val comicPagingSourceFactory: () -> PagingSource<Int, Comic> = {
+        QueryPagingSource(
+            countQuery = database.comicEntityQueries.count(),
+            transacter = database.comicEntityQueries,
+            context = Dispatchers.IO,
+            queryProvider = { limit, offset ->
+                database.comicEntityQueries.selectPaged(
+                    limit,
+                    offset,
+                    OfflineFirstComicRepository::mapComicSelecting
+                )
+            }
+        )
+    }
+
+    val apiClient: ApiClient by lazy {
+        ApiClient(Dispatchers.IO)
+    }
+
+    @OptIn(ExperimentalPagingApi::class)
+    val comicsRemoteMediator: RemoteMediator<Int, Comic> by lazy {
+        ComicsRemoteMediator(comicRepository, apiClient)
+    }
+
+}

--- a/androidApp/src/main/java/com/colibrez/xkcdreader/android/XkcdReaderApplication.kt
+++ b/androidApp/src/main/java/com/colibrez/xkcdreader/android/XkcdReaderApplication.kt
@@ -1,0 +1,12 @@
+package com.colibrez.xkcdreader.android
+
+import android.app.Application
+
+class XkcdReaderApplication : Application() {
+
+    lateinit var dependencyContainer: DependencyContainer
+    override fun onCreate() {
+        super.onCreate()
+        dependencyContainer = DependencyContainer(this)
+    }
+}

--- a/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comic/ComicScreen.kt
+++ b/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comic/ComicScreen.kt
@@ -50,13 +50,9 @@ import androidx.savedstate.SavedStateRegistryOwner
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.AsyncImage
 import coil.imageLoader
-import com.colibrez.xkcdreader.database.DriverFactory
-import com.colibrez.xkcdreader.database.createDatabase
-import com.colibrez.xkcdreader.data.repository.OfflineFirstComicRepository
-import com.colibrez.xkcdreader.database.SqlDelightLocalComicDataSource
+import com.colibrez.xkcdreader.android.XkcdReaderApplication
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
-import kotlinx.coroutines.Dispatchers
 import java.io.File
 
 
@@ -318,12 +314,10 @@ private fun RowScope.ComicTopBarActions(
 fun comicViewModel(
     savedStateRegistryOwner: SavedStateRegistryOwner = LocalSavedStateRegistryOwner.current,
 ): ComicViewModel {
-    val database = createDatabase(DriverFactory(LocalContext.current))
-    val comicRepository =
-        OfflineFirstComicRepository(SqlDelightLocalComicDataSource(Dispatchers.IO, database))
+    val dependencyContainer = (LocalContext.current.applicationContext as XkcdReaderApplication).dependencyContainer
     val factory = ComicViewModel.Factory(
         owner = savedStateRegistryOwner,
-        comicRepository = comicRepository,
+        comicRepository = dependencyContainer.comicRepository,
     )
     return viewModel(factory = factory)
 }

--- a/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comic/ComicViewModel.kt
+++ b/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comic/ComicViewModel.kt
@@ -71,7 +71,7 @@ class ComicViewModel(
             )
         }.stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(),
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
             initialValue = ComicState.Loading(
                 comicNumber = arguments.comicNumber,
                 comicTitle = arguments.comicTitle

--- a/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comiclist/ComicListScreen.kt
+++ b/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comiclist/ComicListScreen.kt
@@ -169,11 +169,7 @@ fun comicListViewModel(savedStateRegistryOwner: SavedStateRegistryOwner = LocalS
                         OfflineFirstComicRepository::mapComicSelecting
                     )
                 }
-            ).also {
-                mediator.invalidate = {
-                    it.invalidate()
-                }
-            }
+            )
         },
         comicRepository = comicRepository,
     )

--- a/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comiclist/ComicListScreen.kt
+++ b/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comiclist/ComicListScreen.kt
@@ -32,20 +32,14 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import androidx.savedstate.SavedStateRegistryOwner
-import app.cash.sqldelight.paging3.QueryPagingSource
 import coil.compose.AsyncImage
-import com.colibrez.xkcdreader.android.data.repository.ComicsRemoteMediator
-import com.colibrez.xkcdreader.database.DriverFactory
-import com.colibrez.xkcdreader.database.createDatabase
-import com.colibrez.xkcdreader.network.ApiClient
-import com.colibrez.xkcdreader.data.repository.OfflineFirstComicRepository
-import com.colibrez.xkcdreader.database.SqlDelightLocalComicDataSource
+import com.colibrez.xkcdreader.android.XkcdReaderApplication
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
-import kotlinx.coroutines.Dispatchers
 
 
 @Destination
@@ -66,6 +60,7 @@ fun ComicListScreen(
     }
 
     val state by viewModel.state.collectAsState()
+
     val lazyPagingItems = state.comics.collectAsLazyPagingItems()
 
     val image: @Composable (imageUrl: String) -> Unit = { imageUrl ->
@@ -95,7 +90,8 @@ fun ComicListScreen(
     LazyColumn {
         items(
             lazyPagingItems.itemCount,
-            key = lazyPagingItems.itemKey { it.comicNumber }
+            key = lazyPagingItems.itemKey { it.comicNumber },
+            contentType = lazyPagingItems.itemContentType { ListComic::class.hashCode() }
         ) { index ->
             val item = lazyPagingItems[index] ?: return@items
             ListItem(
@@ -121,8 +117,8 @@ fun ComicListScreen(
                     IconButton(onClick = {
                         viewModel.handle(
                             ComicListUserAction.ToggleFavorite(
-                                item.comicNumber,
-                                item.isFavorite
+                                comicNum = item.comicNumber,
+                                isFavorite = item.isFavorite
                             )
                         )
                     }) {
@@ -141,37 +137,14 @@ fun ComicListScreen(
 @OptIn(ExperimentalPagingApi::class)
 @Composable
 fun comicListViewModel(savedStateRegistryOwner: SavedStateRegistryOwner = LocalSavedStateRegistryOwner.current): ComicListViewModel {
-    val driverFactory = DriverFactory(LocalContext.current)
-    val database = createDatabase(driverFactory)
-    val apiClient = ApiClient(Dispatchers.IO)
-    val comicRepository = OfflineFirstComicRepository(
-        SqlDelightLocalComicDataSource(
-            ioDispatcher = Dispatchers.IO,
-            database = database
-        )
-    )
-    val mediator = ComicsRemoteMediator(
-        comicRepository = comicRepository,
-        apiClient = apiClient
-    )
+    val dependencyContainer =
+        (LocalContext.current.applicationContext as XkcdReaderApplication).dependencyContainer
+
     val factory = ComicListViewModel.Factory(
-        savedStateRegistryOwner,
-        comicsRemoteMediator = mediator,
-        pagingSourceFactory = {
-            QueryPagingSource(
-                countQuery = database.comicEntityQueries.count(),
-                transacter = database.comicEntityQueries,
-                context = Dispatchers.IO,
-                queryProvider = { limit, offset ->
-                    database.comicEntityQueries.selectPaged(
-                        limit,
-                        offset,
-                        OfflineFirstComicRepository::mapComicSelecting
-                    )
-                }
-            )
-        },
-        comicRepository = comicRepository,
+        owner = savedStateRegistryOwner,
+        comicsRemoteMediator = dependencyContainer.comicsRemoteMediator,
+        pagingSourceFactory = dependencyContainer.comicPagingSourceFactory,
+        comicRepository = dependencyContainer.comicRepository,
     )
     return viewModel(factory = factory)
 }

--- a/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comiclist/ComicListViewModel.kt
+++ b/androidApp/src/main/java/com/colibrez/xkcdreader/android/ui/features/comiclist/ComicListViewModel.kt
@@ -1,6 +1,7 @@
 package com.colibrez.xkcdreader.android.ui.features.comiclist
 
 import android.os.Bundle
+import androidx.compose.runtime.Stable
 import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -44,11 +45,13 @@ data class ListComic(
     val isRead: Boolean
 )
 
+@Stable
 data class ComicListState(
     val comics: Flow<PagingData<ListComic>>
 ) : UiState
 
 @OptIn(ExperimentalPagingApi::class)
+@Stable
 class ComicListViewModel(
     comicsRemoteMediator: RemoteMediator<Int, Comic>,
     pagingSourceFactory: () -> PagingSource<Int, Comic>,
@@ -71,7 +74,7 @@ class ComicListViewModel(
                         isRead = it.isRead
                     )
                 }
-            }
+            }.cachedIn(viewModelScope)
         )
     ).asStateFlow()
 

--- a/shared/src/commonMain/sqldelight/com/colibrez/xkcdreader/database/model/ComicEntity.sq
+++ b/shared/src/commonMain/sqldelight/com/colibrez/xkcdreader/database/model/ComicEntity.sq
@@ -20,7 +20,7 @@ selectAll:
 SELECT * FROM ComicInfo ORDER BY ComicInfo.num;
 
 selectLatest:
-SELECT * FROM ComicInfo ORDER BY ComicInfo.num LIMIT 1;
+SELECT * FROM ComicInfo ORDER BY ComicInfo.num DESC LIMIT 1;
 
 selectPaged:
 SELECT * FROM ComicInfo ORDER BY ComicInfo.num LIMIT :limit OFFSET :offset;


### PR DESCRIPTION
Fixed two bugs related to paging:
* Fixed initial paging logic by fetching the latest item from the DB on APPEND
* Fixed scroll position not getting saved by calling `chachedIn(viewModelScope)` on the PagingDataFlow
    * This would cause the data to not be updated on back navigation, but this was solved by using the same DB instance.
   
